### PR TITLE
Nikhil/email integration

### DIFF
--- a/app/agents/nurture_campaign_agent.py
+++ b/app/agents/nurture_campaign_agent.py
@@ -1,0 +1,99 @@
+# app/agents/nurture_campaign_agent.py
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any, List
+
+from app.data.supabase_repo import SupabaseRepo
+
+log = logging.getLogger("cory.nurture.agent")
+log.setLevel(logging.INFO)
+
+
+class NurtureCampaignAgent:
+    """
+    Ticket 7 Agent: Smart Nurture Campaigns
+
+    Orchestrates a multi-step nurture sequence (e.g., 15 touchpoints)
+    by scheduling personalized outbound emails for a given lead +
+    nurture campaign in Supabase.
+
+    High-level flow:
+    1. Fetch all configured steps for the nurture campaign.
+    2. For each step, compute a scheduled time using delay metadata.
+    3. Insert rows into the scheduled-email table via SupabaseRepo.
+    """
+
+    def __init__(self) -> None:
+        self.repo = SupabaseRepo()
+
+    async def run_campaign(
+        self,
+        lead_id: str,
+        campaign_id: str,
+        *,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Main entry point to schedule all nurture campaign emails for a lead.
+
+        Args:
+            lead_id: The lead/contact identifier to nurture.
+            campaign_id: The nurture_campaigns.id being executed.
+            context: Optional metadata (e.g., registration, program, tags)
+                     that can be embedded into templates.
+
+        Returns:
+            Dict with a simple status + count of steps scheduled, e.g.:
+            {
+                "status": "ok",
+                "steps_scheduled": 15
+            }
+        """
+        log.info("📨 Running nurture campaign for lead=%s campaign=%s", lead_id, campaign_id)
+
+        # 1) Fetch nurture steps (expected ~15 rows)
+        steps: List[Dict[str, Any]] = await self.repo.get_campaign_steps(campaign_id)
+
+        if not steps:
+            log.warning("No steps found for nurture campaign %s", campaign_id)
+            return {"status": "no_steps", "steps_scheduled": 0}
+
+        # 2) Schedule each email with its configured delay
+        results: List[Any] = []
+        base_time = datetime.utcnow()
+        ctx = context or {}
+
+        for index, step in enumerate(steps):
+            # Default pattern: one message per day if delay not specified
+            delay_minutes = step.get("delay_minutes", index * 1440)
+
+            scheduled_for = base_time + timedelta(minutes=delay_minutes)
+
+            payload = {
+                "lead_id": lead_id,
+                "campaign_id": campaign_id,
+                "step_id": step["id"],
+                "template_id": step["template_id"],
+                "scheduled_for": scheduled_for.isoformat(),
+                "context": ctx,
+            }
+
+            log.info(
+                "⏳ Scheduling nurture email for lead=%s step_id=%s at %s",
+                lead_id,
+                step["id"],
+                scheduled_for.isoformat(),
+            )
+
+            # This uses the helper you added in SupabaseRepo
+            result = await self.repo.schedule_nurture_email(payload)
+            results.append(result)
+
+        log.info(
+            "✅ Nurture campaign scheduled for lead=%s: %d steps",
+            lead_id,
+            len(results),
+        )
+        return {"status": "ok", "steps_scheduled": len(results)}

--- a/app/agents/reengagement_campaign_agent.py
+++ b/app/agents/reengagement_campaign_agent.py
@@ -1,0 +1,81 @@
+# app/agents/reengagement_campaign_agent.py
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any, List
+
+from app.data.supabase_repo import SupabaseRepo
+
+log = logging.getLogger("cory.reengagement.agent")
+log.setLevel(logging.INFO)
+
+
+class ReengagementCampaignAgent:
+    """
+    Ticket 8 Agent:
+    Schedules long-tail re-engagement touches (email/SMS/etc.) for dormant leads.
+    """
+
+    def __init__(self) -> None:
+        self.repo = SupabaseRepo()
+
+    async def run_campaign(
+        self,
+        lead_id: str,
+        campaign_id: str,
+        *,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Main entry point to schedule long-term re-engagement touches.
+        """
+
+        log.info(f"🔁 Running re-engagement campaign for lead={lead_id}")
+
+        # 1. Fetch re-engagement steps (could be 10–20 touches)
+        steps: List[Dict[str, Any]] = await self.repo.get_reengagement_steps(
+            campaign_id
+        )
+
+        if not steps:
+            log.warning(
+                f"No re-engagement steps found for campaign {campaign_id}"
+            )
+            return {"status": "no_steps"}
+
+        results: List[Dict[str, Any]] = []
+        base_time = datetime.utcnow()
+
+        for index, step in enumerate(steps):
+            # Typical re-engagement is slow drip: default every 3 days
+            delay_minutes = step.get(
+                "delay_minutes",
+                index * 3 * 24 * 60,  # 3 days per step by default
+            )
+
+            scheduled_for = base_time + timedelta(minutes=delay_minutes)
+
+            payload = {
+                "lead_id": lead_id,
+                "campaign_id": campaign_id,
+                "step_id": step["id"],
+                "template_id": step["template_id"],
+                "scheduled_for": scheduled_for.isoformat(),
+                "context": context or {},
+            }
+
+            log.info(
+                "📬 Scheduling re-engagement step %s for %s",
+                step["id"],
+                scheduled_for,
+            )
+
+            # ✅ Use the correct repo helper name
+            result = await self.repo.schedule_reengagement_message(payload)
+            results.append(result)
+
+        return {
+            "status": "ok",
+            "steps_scheduled": len(results),
+        }

--- a/app/channels/providers/mail_reader.py
+++ b/app/channels/providers/mail_reader.py
@@ -1,0 +1,184 @@
+# app/channels/providers/mail_reader.py
+
+import imaplib
+import email
+from email.header import decode_header, make_header
+from datetime import datetime, timezone
+import os
+import logging
+from typing import Optional
+
+from app.data.db_pg import supabase  # Supabase client
+
+
+logger = logging.getLogger(__name__)
+
+
+def _get_env(name: str, default: Optional[str] = None) -> str:
+    value = os.environ.get(name, default)
+    if value is None:
+        raise RuntimeError(f"Missing env var {name}")
+    return value
+
+
+def connect_imap() -> imaplib.IMAP4_SSL:
+    host = _get_env("IMAP_HOST")
+    port = int(os.environ.get("IMAP_PORT", "993"))
+    username = _get_env("IMAP_USERNAME")
+    password = _get_env("IMAP_PASSWORD")
+
+    imap = imaplib.IMAP4_SSL(host, port)
+    imap.login(username, password)
+    return imap
+
+
+def _decode_header(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    try:
+        return str(make_header(decode_header(value)))
+    except Exception:
+        return value or ""
+
+
+def _get_plain_body(msg: email.message.Message) -> str:
+    if msg.is_multipart():
+        for part in msg.walk():
+            ctype = part.get_content_type()
+            disp = str(part.get("Content-Disposition") or "")
+            if ctype == "text/plain" and "attachment" not in disp:
+                payload = part.get_payload(decode=True)
+                if payload is None:
+                    continue
+                return payload.decode(
+                    part.get_content_charset() or "utf-8",
+                    errors="ignore",
+                )
+    else:
+        payload = msg.get_payload(decode=True)
+        if payload is not None:
+            return payload.decode(
+                msg.get_content_charset() or "utf-8",
+                errors="ignore",
+            )
+    return ""
+
+
+async def _insert_inbound_interaction(from_email: str, msg: email.message.Message):
+    """
+    Map from incoming email -> lead row in Supabase -> insert into interactions.
+
+    Note: we only require lead.id. current_campaign_id is optional and may not
+    exist in all schemas, so we do NOT select it explicitly.
+    """
+
+    # 1) Find matching lead by email in Supabase
+    try:
+        # Case-insensitive match on email
+        lead_resp = (
+            supabase.table("leads")
+            .select("id")  # do NOT request current_campaign_id (column may not exist)
+            .ilike("email", from_email)
+            .limit(1)
+            .execute()
+        )
+    except Exception as e:
+        logger.exception("Supabase error while looking up lead: %s", e)
+        return
+
+    # supabase-py returns .data attribute
+    lead_data = getattr(lead_resp, "data", None) or []
+    if not lead_data:
+        logger.info(
+            "Inbound email from unknown address %s; no matching lead found",
+            from_email,
+        )
+        return
+
+    lead = lead_data[0]
+    lead_id = lead["id"]
+
+    # Optional campaign_id – only use if your leads table actually has it
+    campaign_id = lead.get("current_campaign_id")
+
+    # 2) Extract message details
+    message_id = msg.get("Message-ID")
+    in_reply_to = msg.get("In-Reply-To")
+    subject = _decode_header(msg.get("Subject"))
+    body = _get_plain_body(msg)
+
+    if not message_id:
+        # Fallback to a pseudo-external id
+        message_id = f"{from_email}|{subject}|{datetime.now(timezone.utc).isoformat()}"
+
+    # 3) Insert into interactions table in Supabase
+    interaction_payload = {
+        "lead_id": lead_id,
+        "campaign_id": campaign_id,
+        "channel": "email",
+        "direction": "inbound",
+        "status": "completed",
+        "content": body,
+        "metadata": {
+            "subject": subject,
+            "in_reply_to": in_reply_to,
+            "message_id": message_id,
+            "from_email": from_email,
+        },
+        "external_id": message_id,
+    }
+
+    try:
+        # Upsert on external_id so we don't double-insert the same message
+        supabase.table("interactions").upsert(
+            interaction_payload, on_conflict="external_id"
+        ).execute()
+        logger.info(
+            "Stored inbound email for lead %s (campaign=%s) subject=%s",
+            lead_id,
+            campaign_id,
+            subject,
+        )
+    except Exception as e:
+        logger.exception("Supabase error while inserting interaction: %s", e)
+
+
+async def poll_once():
+    """Run a single IMAP poll and store any new messages into Supabase."""
+    imap = connect_imap()
+    try:
+        imap.select("INBOX")
+
+        # Search for unseen messages
+        status, data = imap.search(None, "UNSEEN")
+        if status != "OK":
+            logger.error("IMAP search failed: %s", status)
+            return
+
+        ids = data[0].split()
+        if not ids:
+            return
+
+        for msg_id in ids:
+            res, msg_data = imap.fetch(msg_id, "(RFC822)")
+            if res != "OK":
+                logger.error("IMAP fetch failed for id %s: %s", msg_id, res)
+                continue
+
+            raw_email = msg_data[0][1]
+            msg = email.message_from_bytes(raw_email)
+
+            from_header = msg.get("From", "")
+            from_email = email.utils.parseaddr(from_header)[1]
+
+            await _insert_inbound_interaction(from_email, msg)
+
+            # Mark as seen so we don't process again
+            imap.store(msg_id, "+FLAGS", "\\Seen")
+
+    finally:
+        try:
+            imap.close()
+        except Exception:
+            pass
+        imap.logout()

--- a/app/data/db_pg.py
+++ b/app/data/db_pg.py
@@ -1,17 +1,126 @@
 # app/data/db_pg.py
-import os, asyncpg
 
-_DSN = os.getenv("DATABASE_URL")
-_pool = None
+import os
+import asyncpg
+from typing import Any, Dict, List, Optional
+from supabase import create_client
 
-async def init_db_pool():
+
+# ---------------------------------------------------------------------
+#  SUPABASE CLIENT (HTTP API)
+# ---------------------------------------------------------------------
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+
+# Prefer SUPABASE_SERVICE_KEY, but fall back to SUPABASE_SERVICE_ROLE_KEY
+SUPABASE_SERVICE_KEY = (
+    os.getenv("SUPABASE_SERVICE_KEY")
+    or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+)
+
+if not SUPABASE_URL:
+    raise RuntimeError(
+        "Missing SUPABASE_URL in environment (.env). "
+        "Get it from Supabase → Settings → API."
+    )
+
+if not SUPABASE_SERVICE_KEY:
+    raise RuntimeError(
+        "Missing SUPABASE_SERVICE_KEY / SUPABASE_SERVICE_ROLE_KEY in environment (.env). "
+        "Use the *service_role* key from Supabase (NOT the anon key)."
+    )
+
+# Create supabase client
+supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_KEY)
+
+
+# ---------------------------------------------------------------------
+#  POSTGRES CONNECTION (asyncpg)
+# ---------------------------------------------------------------------
+
+# DATABASE_URL should point to the Supabase Postgres DSN
+_DSN: Optional[str] = os.getenv("DATABASE_URL")
+
+_pool: Optional[asyncpg.Pool] = None
+
+
+async def init_db_pool() -> asyncpg.Pool:
+    """
+    Initialize the asyncpg pool once.
+    Called at startup by email_ingest_daemon + workflows.
+    """
     global _pool
+
     if _pool is None:
-        _pool = await asyncpg.create_pool(dsn=_DSN, min_size=1, max_size=5)
+        if not _DSN:
+            raise RuntimeError(
+                "DATABASE_URL is not set in .env. "
+                "Use the Supabase Postgres DSN from Settings → Database."
+            )
+
+        _pool = await asyncpg.create_pool(
+            dsn=_DSN,
+            min_size=1,
+            max_size=5,
+        )
+
     return _pool
 
-async def run_query(sql: str, *args):
+
+def get_pool() -> asyncpg.Pool:
+    """
+    Returns the active pool.
+    """
+    if _pool is None:
+        raise RuntimeError(
+            "DB pool not initialized — call init_db_pool() first."
+        )
+    return _pool
+
+
+# ---------------------------------------------------------------------
+#  QUERY HELPERS
+# ---------------------------------------------------------------------
+
+async def fetchrow(sql: str, *args: Any) -> Optional[Dict[str, Any]]:
+    """
+    Fetch exactly one row or None.
+    """
     pool = _pool or await init_db_pool()
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(sql, *args)
+        return dict(row) if row is not None else None
+
+
+async def fetch(sql: str, *args: Any) -> List[Dict[str, Any]]:
+    """
+    Fetch multiple rows, returned as list of dicts.
+    """
+    pool = _pool or await init_db_pool()
+
     async with pool.acquire() as conn:
         rows = await conn.fetch(sql, *args)
         return [dict(r) for r in rows]
+
+
+async def execute(sql: str, *args: Any) -> str:
+    """
+    Execute INSERT / UPDATE / DELETE.
+    Returns asyncpg's status string.
+    """
+    pool = _pool or await init_db_pool()
+
+    async with pool.acquire() as conn:
+        return await conn.execute(sql, *args)
+
+
+# ---------------------------------------------------------------------
+#  LEGACY COMPAT WRAPPER
+# ---------------------------------------------------------------------
+
+async def run_query(sql: str, *args: Any) -> List[Dict[str, Any]]:
+    """
+    Legacy helper (same as fetch()).
+    """
+    return await fetch(sql, *args)

--- a/app/data/supabase_repo.py
+++ b/app/data/supabase_repo.py
@@ -266,6 +266,21 @@ class SupabaseRepo:
             return rows[0]
         return rows
 
+    # --- Re-engagement Campaign Helpers (Ticket 8) ------------------------
+
+    async def schedule_reengagement_touch(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Insert a scheduled re-engagement touch row.
+
+        For now, we also use the same `scheduled_emails` (or generic scheduled
+        outbound table) as nurture; the calling code can differentiate by
+        campaign_id or any extra fields in `payload`.
+        """
+        rows = await insert("scheduled_emails", payload)
+        if isinstance(rows, list) and rows:
+            return rows[0]
+        return rows
+
 
 # ===============================================================
 #  Generic Logging & RPCs

--- a/app/data/supabase_repo.py
+++ b/app/data/supabase_repo.py
@@ -1,7 +1,7 @@
 # app/data/supabase_repo.py
 from __future__ import annotations
 import os, json, httpx
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from datetime import datetime
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 from temporalio import activity
@@ -102,7 +102,7 @@ async def patch(table: str, query: str, json_body: dict):
 
 
 # ===============================================================
-#  Voice Conversation / Synthflow Support + Appointments
+#  Voice Conversation / Synthflow Support + Appointments + Nurture
 # ===============================================================
 
 class SupabaseRepo:
@@ -229,6 +229,42 @@ class SupabaseRepo:
         }
         payload = {k: v for k, v in payload.items() if v is not None}
         return await insert("appointments", payload)
+
+    # --- Nurture Campaign Helpers (Ticket 7) -------------------------------
+
+    async def get_campaign_steps(self, campaign_id: str) -> List[Dict[str, Any]]:
+        """
+        Fetch ordered nurture campaign steps for a given campaign.
+
+        Expects a `nurture_steps` (or similarly named) table with:
+          - campaign_id
+          - step_number
+          - template_id
+          - delay_minutes (optional)
+        """
+        url, key, schema = _cfg()
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.get(
+                f"{url}/rest/v1/nurture_steps"
+                f"?campaign_id=eq.{campaign_id}&order=step_number.asc",
+                headers={**_headers(key), "Accept-Profile": schema},
+            )
+        _raise_if_transient(r.status_code, r.text)
+        r.raise_for_status()
+        data = r.json()
+        return data or []
+
+    async def schedule_nurture_email(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Insert a scheduled nurture email row.
+
+        Expects a `scheduled_emails` (or equivalent) table which stores
+        scheduled outbound nurture messages.
+        """
+        rows = await insert("scheduled_emails", payload)
+        if isinstance(rows, list) and rows:
+            return rows[0]
+        return rows
 
 
 # ===============================================================

--- a/app/data/supabase_repo.py
+++ b/app/data/supabase_repo.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import os, json, httpx
 from typing import Optional, Dict, Any, List
-from datetime import datetime
+from datetime import datetime, timedelta
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 from temporalio import activity
 from supabase import create_client, Client
@@ -281,6 +281,51 @@ class SupabaseRepo:
             return rows[0]
         return rows
 
+    # --- Reply / Re-engagement Helpers (Ticket 10-ish) --------------------
+
+    async def has_email_reply_for_enrollment(
+        self,
+        enrollment_id: str,
+        *,
+        lookback_minutes: int = 120,
+    ) -> bool:
+        """
+        Return True if we see any inbound email message for this enrollment
+        in the last `lookback_minutes` minutes.
+
+        Assumes an inbound-email pipeline that writes rows to `message` with:
+          - enrollment_id
+          - channel = 'email'
+          - direction = 'inbound'
+          - created_at (timestamp)
+
+        If your schema differs, adjust the REST filter below.
+        """
+        url, key, schema = _cfg()
+
+        since = datetime.utcnow() - timedelta(minutes=lookback_minutes)
+        since_iso = since.isoformat()
+
+        query = (
+            f"enrollment_id=eq.{enrollment_id}"
+            "&channel=eq.email"
+            "&direction=eq.inbound"
+            f"&created_at=gte.{since_iso}"
+            "&select=id"
+            "&limit=1"
+        )
+
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.get(
+                f"{url}/rest/v1/message?{query}",
+                headers={**_headers(key), "Accept-Profile": schema},
+            )
+
+        _raise_if_transient(r.status_code, r.text)
+        r.raise_for_status()
+        data = r.json()
+        return bool(data)
+
 
 # ===============================================================
 #  Generic Logging & RPCs
@@ -334,6 +379,6 @@ async def patch_activity(table: str, query: str, json_body: dict):
             r.raise_for_status()
 
         return {"status": r.status_code, "data": r.json()}
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"[PATCH_ACTIVITY_EXCEPTION] {type(e).__name__}: {e}")
         raise

--- a/app/orchestrator/temporal/activities/appointment_book.py
+++ b/app/orchestrator/temporal/activities/appointment_book.py
@@ -1,105 +1,48 @@
 # app/orchestrator/temporal/activities/appointment_book.py
-
-"""
-appointment_book.py
-----------------------------------------------------------
-Temporal activity wrapper around AppointmentSchedulerAgent.
-
-Used by BookAppointmentWorkflow to:
-- Normalize input payload (IDs, scheduled time, notes, source)
-- Call AppointmentSchedulerAgent to create an appointment row
-- Link appointment back to enrollment
-
-For now, `scheduled_for_iso` is required or inferred as "now"
-if missing/invalid. Later, you can populate it directly from
-Synthflow's `appointment` block in the voice webhook payload.
-"""
-
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+import logging
+from typing import Dict, Any
 
 from temporalio import activity
 
 from app.agents.appointment_scheduler_agent import AppointmentSchedulerAgent
 
+log = logging.getLogger("cory.appointment.book")
 
-def _parse_iso_datetime(value: Optional[str]) -> datetime:
+
+@activity.defn(name="book_appointment")
+async def book_appointment(payload: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Parse an ISO8601 string into a UTC datetime.
-    Fallback: return "now" UTC if parsing fails or value is None.
+    Temporal activity used by BookAppointmentWorkflow and the worker.
+
+    Expects a payload like:
+        {
+            "lead_id": "lead-123",
+            "enrollment_id": "enr-1" or None,
+            "campaign_id": "camp-1" or None,
+            "channel": "voice" | "email" | "sms",
+            "source": "cory",
+            "candidate_slots": [...optional...],
+            "notes": "optional notes",
+        }
+
+    The AppointmentSchedulerAgent is responsible for turning this into an
+    appointments row (or similar) in Supabase.
     """
-    if not value:
-        return datetime.now(timezone.utc)
-
-    try:
-        dt = datetime.fromisoformat(value)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-        return dt
-    except Exception:
-        # Conservative fallback — log via activity logger and use now()
-        activity.logger.warning("Failed to parse scheduled_for_iso=%s; defaulting to now()", value)
-        return datetime.now(timezone.utc)
-
-
-@activity.defn
-async def book_appointment_activity(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Temporal activity entry point.
-
-    Args (expected keys in `payload`):
-        enrollment_id: str (preferred) — PK of public.enrollment
-        registration_id: Optional[str] — enrollment.registration_id
-        scheduled_for_iso: Optional[str] — ISO8601 datetime string
-        notes: Optional[str] — notes for appointment
-        source: Optional[str] — origin label (e.g. "voice_ready_to_enroll")
-
-    Returns:
-        Dict with:
-            {
-              "appointment": {...},  # row from public.appointments
-              "enrollment": {...},   # row from public.enrollment
-            }
-    """
-    logger = activity.logger
-
-    enrollment_id: Optional[str] = payload.get("enrollment_id")
-    registration_id: Optional[str] = payload.get("registration_id")
-    scheduled_for_iso: Optional[str] = payload.get("scheduled_for_iso")
-    notes: Optional[str] = payload.get("notes")
-    source: str = payload.get("source", "voice_ready_to_enroll")
-
-    if not enrollment_id and not registration_id:
-        raise ValueError("book_appointment_activity requires enrollment_id or registration_id")
-
-    scheduled_for = _parse_iso_datetime(scheduled_for_iso)
-
-    logger.info(
-        "📅 book_appointment_activity: booking appointment | enrollment_id=%s | registration_id=%s | when=%s | source=%s",
-        enrollment_id,
-        registration_id,
-        scheduled_for.isoformat(),
-        source,
-    )
-
     agent = AppointmentSchedulerAgent()
 
-    result = await agent.schedule_from_enrollment(
-        enrollment_id=enrollment_id,
-        registration_id=registration_id,
-        scheduled_for=scheduled_for,
-        notes=notes,
-        source=source,
+    # Be tolerant of slightly different method names on the agent.
+    scheduler_fn = getattr(agent, "schedule_appointment", None) or getattr(
+        agent, "schedule"
     )
 
-    logger.info(
-        "✅ book_appointment_activity: appointment_id=%s linked to enrollment_id=%s",
-        result.get("appointment", {}).get("id"),
-        result.get("enrollment", {}).get("id"),
-    )
+    log.info("📅 [appointment_book] booking appointment with payload=%s", payload)
 
-    return result
+    try:
+        result = await scheduler_fn(**payload)
+        log.info("✅ [appointment_book] appointment booked: %s", result)
+        return result
+    except Exception as e:  # noqa: BLE001
+        log.exception("❌ [appointment_book] failed to book appointment: %s", e)
+        raise

--- a/app/orchestrator/temporal/activities/email_reply_check.py
+++ b/app/orchestrator/temporal/activities/email_reply_check.py
@@ -1,0 +1,34 @@
+# app/orchestrator/temporal/activities/email_reply_check.py
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from temporalio import activity
+
+from app.data.supabase_repo import SupabaseRepo
+
+
+@activity.defn(name="email_reply_check")
+async def email_reply_check(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Check whether we have an inbound email reply for a given enrollment.
+
+    Expected payload:
+      {
+        "enrollment_id": "enr-123",
+        "lookback_minutes": 120,  # optional
+      }
+
+    Returns:
+      {"has_reply": bool}
+    """
+    repo = SupabaseRepo()
+    enrollment_id = payload["enrollment_id"]
+    lookback = int(payload.get("lookback_minutes", 120))
+
+    has_reply = await repo.has_email_reply_for_enrollment(
+        enrollment_id=enrollment_id,
+        lookback_minutes=lookback,
+    )
+
+    return {"has_reply": has_reply}

--- a/app/orchestrator/temporal/worker.py
+++ b/app/orchestrator/temporal/worker.py
@@ -31,6 +31,9 @@ from app.orchestrator.temporal.activities.handoff_create import (
     mark_timed_out,
 )
 from app.orchestrator.temporal.activities.appointment_book import book_appointment
+from app.orchestrator.temporal.activities.email_reply_check import (
+    email_reply_check,
+)
 from app.orchestrator.temporal.activities import (
     rag_retrieve,
     rag_redact,
@@ -185,7 +188,8 @@ async def run() -> None:
         repo.insert_interaction,
         repo.patch_activity,
         generate_followup_message,
-        book_appointment,  # appointment booking activity
+        book_appointment,      # appointment booking activity
+        email_reply_check,     # NEW: check for inbound email replies
     ]
 
     match_workflows = [ProgramMatchWf]

--- a/app/orchestrator/temporal/workflows/email_nurture_sequence.py
+++ b/app/orchestrator/temporal/workflows/email_nurture_sequence.py
@@ -1,0 +1,128 @@
+# app/orchestrator/temporal/workflows/email_nurture_sequence.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Dict, Any, Optional
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+# Temporal-safe imports
+with workflow.unsafe.imports_passed_through():
+    from app.orchestrator.temporal.activities.email_send import email_send
+    from app.orchestrator.temporal.activities.email_reply_check import (
+        email_reply_check,
+    )
+
+
+@dataclass
+class EmailNurtureInput:
+    """Input for EmailNurtureWorkflow."""
+
+    enrollment_id: str
+    lead: Dict[str, Any]
+    organization: Dict[str, Any]
+    campaign_id: Optional[str] = None
+    to_email: Optional[str] = None
+    emails_count: int = 5
+    delay_seconds: int = 60
+    subject_prefix: str = "[Cory Test] Nurture Email"
+    template_name: Optional[str] = None  # if you want templates later
+
+
+@workflow.defn
+class EmailNurtureWorkflow:
+    """
+    Simple test workflow:
+
+    - Sends up to N emails, `delay_seconds` apart.
+    - Before each send, checks Supabase for an inbound email reply.
+    - If a reply exists, it stops early and returns "stopped_due_to_reply".
+    """
+
+    @workflow.run
+    async def run(self, inp: EmailNurtureInput) -> str:
+        logger = workflow.logger
+
+        to_email = inp.to_email or inp.lead.get("email")
+        if not to_email:
+            raise ValueError("EmailNurtureWorkflow requires to_email or lead['email'].")
+
+        logger.info(
+            "📧 Starting EmailNurtureWorkflow | enrollment=%s, to=%s, max_emails=%d",
+            inp.enrollment_id,
+            to_email,
+            inp.emails_count,
+        )
+
+        for idx in range(1, inp.emails_count + 1):
+            # 1️⃣ Check if there is already a reply recorded in Supabase
+            reply_result = await workflow.execute_activity(
+                email_reply_check,
+                {
+                    "enrollment_id": inp.enrollment_id,
+                    "lookback_minutes": 240,
+                },
+                schedule_to_close_timeout=timedelta(seconds=10),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
+
+            if reply_result.get("has_reply"):
+                logger.info(
+                    "✅ Reply detected for enrollment %s — "
+                    "stopping nurture sequence at email #%d",
+                    inp.enrollment_id,
+                    idx,
+                )
+                return "stopped_due_to_reply"
+
+            # 2️⃣ No reply yet → send next email
+            subject = f"{inp.subject_prefix} {idx} of {inp.emails_count}"
+            body = (
+                f"Hi {inp.lead.get('first_name', 'there')},\n\n"
+                f"This is nurture email {idx} of {inp.emails_count}.\n\n"
+                "Cory is testing multi-step email follow-up."
+            )
+
+            email_payload = {
+                "lead": inp.lead,
+                "organization": inp.organization,
+                "to": to_email,
+                "subject": subject,
+                "template": inp.template_name,
+                "variables": {},
+                "campaign_id": inp.campaign_id,
+            }
+
+            logger.info(
+                "📨 Sending nurture email #%d/%d to %s",
+                idx,
+                inp.emails_count,
+                to_email,
+            )
+
+            await workflow.execute_activity(
+                email_send,
+                inp.enrollment_id,
+                email_payload,
+                schedule_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+
+            # 3️⃣ Wait before next email, unless that was the last one
+            if idx < inp.emails_count:
+                delay = timedelta(seconds=inp.delay_seconds)
+                logger.info(
+                    "⏳ Sleeping %s seconds before next email",
+                    inp.delay_seconds,
+                )
+                await workflow.sleep(delay)
+
+        logger.info(
+            "🏁 Completed all %d nurture emails with no reply detected "
+            "for enrollment %s",
+            inp.emails_count,
+            inp.enrollment_id,
+        )
+        return "completed_no_reply"

--- a/app/orchestrator/temporal/workflows/followup_callback.py
+++ b/app/orchestrator/temporal/workflows/followup_callback.py
@@ -11,9 +11,9 @@ from temporalio import workflow
 from app.agents.followup_scheduler_agent import FollowUpSchedulerAgent
 from app.agents.voice_conversation_agent import VoiceConversationAgent
 from app.data.supabase_repo import SupabaseRepo
-from app.orchestrator.temporal.activities.sms_send import send_sms  # adjust to your actual name
-from app.orchestrator.temporal.activities.email_send import send_email  # adjust
-from app.orchestrator.temporal.activities.voice_start import start_voice_call  # adjust
+from app.orchestrator.temporal.activities.sms_send import sms_send  # adjust to your actual name
+from app.orchestrator.temporal.activities.email_send import email_send
+from app.orchestrator.temporal.activities.voice_start import voice_start  # adjust
 
 
 @dataclass
@@ -59,7 +59,7 @@ class CallbackFollowupWorkflow:
 
             if step.channel == "sms":
                 await workflow.execute_activity(
-                    send_sms,
+                    sms_send,
                     {
                         "project_id": inp.project_id,
                         "enrollment_id": inp.enrollment_id,
@@ -73,7 +73,7 @@ class CallbackFollowupWorkflow:
                 # Reuse the existing voice_start activity which internally
                 # calls VoiceConversationAgent and Synthflow
                 await workflow.execute_activity(
-                    start_voice_call,
+                    voice_start,
                     {
                         "org_id": inp.org_id,
                         "enrollment_id": inp.enrollment_id,
@@ -86,7 +86,7 @@ class CallbackFollowupWorkflow:
 
             elif step.channel == "email":
                 await workflow.execute_activity(
-                    send_email,
+                    email_send,
                     {
                         "project_id": inp.project_id,
                         "enrollment_id": inp.enrollment_id,

--- a/app/orchestrator/temporal/workflows/nurture_campaign_workflow.py
+++ b/app/orchestrator/temporal/workflows/nurture_campaign_workflow.py
@@ -1,0 +1,77 @@
+# app/orchestrator/temporal/workflows/nurture_campaign_workflow.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Any, Optional
+
+from temporalio import workflow, activity
+
+from app.agents.nurture_campaign_agent import NurtureCampaignAgent
+
+
+# ===============================================================
+# Workflow Input Model
+# ===============================================================
+
+@dataclass
+class NurtureCampaignInput:
+    """
+    Payload for starting a Smart Nurture Campaign workflow.
+
+    Attributes:
+        lead_id: The lead/contact we’re nurturing.
+        campaign_id: ID of the nurture_campaigns row to execute.
+        context: Optional extra context (program, registration, tags, etc.)
+    """
+    lead_id: str
+    campaign_id: str
+    context: Optional[Dict[str, Any]] = None
+
+
+# ===============================================================
+# Activity Wrapper
+# ===============================================================
+
+@activity.defn
+async def run_nurture_campaign_activity(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Runs NurtureCampaignAgent inside a Temporal activity so that
+    DB / network IO is off the workflow thread.
+    """
+    agent = NurtureCampaignAgent()
+    return await agent.run_campaign(
+        lead_id=payload["lead_id"],
+        campaign_id=payload["campaign_id"],
+        context=payload.get("context") or {},
+    )
+
+
+# ===============================================================
+# Workflow Definition
+# ===============================================================
+
+@workflow.defn
+class NurtureCampaignWorkflow:
+    """
+    Ticket 7 workflow:
+
+    - Accepts lead + nurture campaign id (+ optional context)
+    - Delegates to NurtureCampaignAgent via an activity
+    - Returns a summary of how many steps were scheduled
+    """
+
+    @workflow.run
+    async def run(self, inp: NurtureCampaignInput) -> Dict[str, Any]:
+        payload = {
+            "lead_id": inp.lead_id,
+            "campaign_id": inp.campaign_id,
+            "context": inp.context or {},
+        }
+
+        result = await workflow.execute_activity(
+            run_nurture_campaign_activity,
+            payload,
+            schedule_to_close_timeout=300,  # 5 minutes is plenty
+        )
+
+        return result

--- a/app/orchestrator/temporal/workflows/reengagement_campaign_workflow.py
+++ b/app/orchestrator/temporal/workflows/reengagement_campaign_workflow.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Dict, Any
+
+from temporalio import workflow
+from temporalio import activity
+
+from app.agents.reengagement_campaign_agent import ReengagementCampaignAgent
+
+
+# ===============================================================
+# Workflow Input Model
+# ===============================================================
+
+@dataclass
+class ReengagementCampaignInput:
+    lead_id: str
+    campaign_id: str
+    context: Optional[Dict[str, Any]] = None
+
+
+# ===============================================================
+# Activity Wrapper
+# ===============================================================
+
+@activity.defn
+async def run_reengagement_activity(payload: dict) -> dict:
+    agent = ReengagementCampaignAgent()
+    return await agent.run_campaign(**payload)
+
+
+# ===============================================================
+# Workflow Definition
+# ===============================================================
+
+@workflow.defn
+class ReengagementCampaignWorkflow:
+    """
+    Ticket 8 workflow:
+    - receives lead/campaign info
+    - invokes ReengagementCampaignAgent inside an activity
+    """
+
+    @workflow.run
+    async def run(self, inp: ReengagementCampaignInput) -> Dict[str, Any]:
+        payload = {
+            "lead_id": inp.lead_id,
+            "campaign_id": inp.campaign_id,
+            "context": inp.context or {},
+        }
+
+        result = await workflow.execute_activity(
+            run_reengagement_activity,
+            payload,
+            schedule_to_close_timeout=30,
+        )
+
+        return result

--- a/app/orchestrator/temporal/workflows/simulated_followup.py
+++ b/app/orchestrator/temporal/workflows/simulated_followup.py
@@ -8,10 +8,12 @@ Runs a simulated outreach cycle fully within Temporal.
 - Agent generates next outbound message (no external API)
 - Each communication is logged to Supabase (interactions table)
 - Optional simulated inbound replies
-- Workflow progress is visible in Temporal UI
+- Updates campaign_enrollments timing
+- (Ticket 9) If intent/next_action are present on the lead, they are
+  persisted into lead_campaign_steps for downstream branching.
 """
 
-from datetime import timedelta, datetime, timezone
+from datetime import timedelta
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -35,11 +37,17 @@ class SimulatedFollowupWorkflow:
                     "name": str,
                     "email": str,
                     "phone": str,
-                    "next_channel": "sms" | "email" | "voice"
+                    "next_channel": "sms" | "email" | "voice",
+                    # (optional, Ticket 9)
+                    "intent": str,
+                    "next_action": str,
                 }
         """
         logger = workflow.logger
-        logger.info(f"🤖 Starting Simulated Follow-up Workflow for {lead.get('name')}")
+        logger.info(
+            "🤖 Starting Simulated Follow-up Workflow for %s",
+            lead.get("name"),
+        )
 
         enrollment_id = lead["id"]
         channel = lead.get("next_channel", "sms")
@@ -56,57 +64,98 @@ class SimulatedFollowupWorkflow:
         # 2️⃣ Log outbound message
         await workflow.execute_activity(
             repo.insert_interaction,
-            args=[enrollment_id, channel, "outbound", "completed", message, "ai_generated"],
+            args=[
+                enrollment_id,
+                channel,
+                "outbound",
+                "completed",
+                message,
+                "ai_generated",
+            ],
             schedule_to_close_timeout=timedelta(seconds=10),
             retry_policy=RetryPolicy(maximum_attempts=2),
         )
-        logger.info(f"💬 Outbound message logged for {lead_name}")
+        logger.info("💬 Outbound message logged for %s", lead_name)
 
         # 3️⃣ Wait a simulated delay (represents waiting for student)
         await workflow.sleep(5)
 
         # 4️⃣ Simulated inbound reply (for testing)
-        import random
         if workflow.random().random() < 0.6:
-            simulated_reply = workflow.random().choice([
-                "Thanks, I’ll review it soon.",
-                "Can you send more info about the program?",
-                "Not right now, maybe next month.",
-                "Yes, I’m interested — when is the deadline?",
-            ])
+            simulated_reply = workflow.random().choice(
+                [
+                    "Thanks, I’ll review it soon.",
+                    "Can you send more info about the program?",
+                    "Not right now, maybe next month.",
+                    "Yes, I’m interested — when is the deadline?",
+                ]
+            )
             await workflow.execute_activity(
                 repo.insert_interaction,
-                args=[enrollment_id, channel, "inbound", "completed", simulated_reply, "user_reply"],
+                args=[
+                    enrollment_id,
+                    channel,
+                    "inbound",
+                    "completed",
+                    simulated_reply,
+                    "user_reply",
+                ],
                 schedule_to_close_timeout=timedelta(seconds=10),
                 retry_policy=RetryPolicy(maximum_attempts=2),
             )
-            logger.info(f"📩 Simulated inbound reply logged for {lead_name}")
+            logger.info("📩 Simulated inbound reply logged for %s", lead_name)
         else:
-            logger.info(f"🕓 No simulated reply for {lead_name}")
+            logger.info("🕓 No simulated reply for %s", lead_name)
+
+        # 4.5️⃣ (Ticket 9) Persist intent / next_action if present on lead
+        intent = lead.get("intent")
+        next_action = lead.get("next_action")
+        if intent or next_action:
+            now_iso = workflow.now().isoformat()
+            await workflow.execute_activity(
+                repo.patch_activity,
+                args=[
+                    "lead_campaign_steps",
+                    f"enrollment_id=eq.{enrollment_id}",
+                    {
+                        "intent": intent,
+                        "next_action": next_action,
+                        "updated_at": now_iso,
+                    },
+                ],
+                schedule_to_close_timeout=timedelta(seconds=10),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+            logger.info(
+                "🧭 Updated lead_campaign_steps for %s with intent=%s next_action=%s",
+                lead_name,
+                intent,
+                next_action,
+            )
 
         # 5️⃣ Mark next follow-up timing in Supabase
         next_time = workflow.now().isoformat()
         await workflow.execute_activity(
-        repo.patch_activity,
-        args=[
-            "campaign_enrollments",
-            f"id=eq.{enrollment_id}",
-            {
-                "last_contacted_at": next_time,
-                "updated_at": next_time,
-                "status": "active",
-            },
+            repo.patch_activity,
+            args=[
+                "campaign_enrollments",
+                f"id=eq.{enrollment_id}",
+                {
+                    "last_contacted_at": next_time,
+                    "updated_at": next_time,
+                    "status": "active",
+                },
             ],
             schedule_to_close_timeout=timedelta(seconds=10),
             retry_policy=RetryPolicy(maximum_attempts=1),
         )
 
-        logger.info(f"✅ Workflow completed for {lead_name}")
+        logger.info("✅ Workflow completed for %s", lead_name)
         return "completed"
 
     # 🧠 Optional: signal handler for external replies
     @workflow.signal
     async def inbound_reply(self, channel: str, message: str):
         """Handle a live inbound message signal from student."""
-        workflow.logger.info(f"⚡ Inbound signal on {channel}: {message}")
+        workflow.logger.info("⚡ Inbound signal on %s: %s", channel, message)
         self._last_inbound = {"channel": channel, "message": message}

--- a/app/orchestrator/temporal/workflows/workflow_registry.py
+++ b/app/orchestrator/temporal/workflows/workflow_registry.py
@@ -1,12 +1,106 @@
 # app/orchestrator/temporal/workflows/workflow_registry.py
-from typing import Optional
-from temporalio.client import WorkflowHandle
+from __future__ import annotations
+
+from typing import Optional, Any, Type
+from temporalio.client import WorkflowHandle, Client
+from temporalio import workflow
 
 _latest_handle: Optional[WorkflowHandle] = None
+_client: Optional[Client] = None
+
+
+# ===============================================================
+#  Handle Management
+# ===============================================================
 
 def set_current_handle(handle: WorkflowHandle):
+    """Store the most recent workflow handle for later inspection."""
     global _latest_handle
     _latest_handle = handle
 
+
 def get_current_handle() -> Optional[WorkflowHandle]:
+    """Return the most recently started workflow handle."""
     return _latest_handle
+
+
+def clear_current_handle():
+    """Reset stored handle (mostly used in tests)."""
+    global _latest_handle
+    _latest_handle = None
+
+
+# ===============================================================
+#  Client Management
+# ===============================================================
+
+def set_client(client: Client):
+    """Set the Temporal client once, typically at worker startup."""
+    global _client
+    _client = client
+
+
+def get_client() -> Client:
+    """Return the globally configured Temporal client."""
+    if _client is None:
+        raise RuntimeError("Temporal client not yet initialized in workflow_registry.")
+    return _client
+
+
+# ===============================================================
+#  Workflow Launcher Helpers
+# ===============================================================
+
+async def start_workflow(
+    workflow_type: Type[Any],
+    input_obj: Any,
+    *,
+    workflow_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+) -> WorkflowHandle:
+    """
+    Unified helper to start any workflow and automatically register its handle.
+    Used by Tickets 5, 7, 8, 9.
+
+    Args:
+        workflow_type: The workflow class reference (not string).
+        input_obj: The dataclass input to pass to workflow.run().
+        workflow_id: Optional explicit workflow ID.
+        task_queue: Optional task queue override.
+    """
+    client = get_client()
+
+    handle = await client.start_workflow(
+        workflow_type,
+        input_obj,
+        id=workflow_id,
+        task_queue=task_queue or "cory-default",
+    )
+
+    set_current_handle(handle)
+    return handle
+
+
+# ===============================================================
+#  Query Helpers (Optional Safety Utilities)
+# ===============================================================
+
+async def get_workflow_result(handle: Optional[WorkflowHandle] = None):
+    """
+    Return the result of a workflow. If handle omitted, uses the latest handle.
+    """
+    h = handle or get_current_handle()
+    if h is None:
+        raise RuntimeError("No workflow handle available for get_workflow_result().")
+    return await h.result()
+
+
+async def get_workflow_status(handle: Optional[WorkflowHandle] = None):
+    """
+    Query a workflow's status (running, completed, failed, etc.)
+    """
+    h = handle or get_current_handle()
+    if h is None:
+        raise RuntimeError("No workflow handle available for get_workflow_status().")
+    desc = await h.describe()
+    return desc.status.name

--- a/cripts/print_supabase_env.py
+++ b/cripts/print_supabase_env.py
@@ -1,0 +1,7 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+print("SUPABASE_URL:", os.getenv("SUPABASE_URL"))
+print("SUPABASE_SERVICE_KEY set?:", bool(os.getenv("SUPABASE_SERVICE_KEY")))

--- a/scripts/email_ingest_daemon.py
+++ b/scripts/email_ingest_daemon.py
@@ -1,0 +1,61 @@
+# scripts/email_ingest_daemon.py
+
+import asyncio
+import os
+import sys
+import logging
+from datetime import datetime
+
+from dotenv import load_dotenv
+
+# ---------------------------------------------------------------------
+#  Bootstrap: sys.path + .env
+# ---------------------------------------------------------------------
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+# Load .env before importing anything from app.*
+load_dotenv()
+
+from app.channels.providers.mail_reader import poll_once  # noqa: E402
+
+# ---------------------------------------------------------------------
+#  Logging
+# ---------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------
+#  Main poll loop
+# ---------------------------------------------------------------------
+
+async def main() -> None:
+    """
+    Simple IMAP polling daemon.
+
+    - Every IMAP_POLL_SECONDS (default 30s):
+        * logs a tick
+        * calls poll_once() to ingest any new emails
+    """
+    poll_seconds = int(os.environ.get("IMAP_POLL_SECONDS", "30"))
+
+    logger.info("Starting email ingest daemon (poll interval=%ss)", poll_seconds)
+
+    while True:
+        logger.info("IMAP poll tick %s", datetime.utcnow().isoformat())
+        try:
+            await poll_once()
+        except Exception as e:
+            logger.exception("IMAP poll failed: %s", e)
+        await asyncio.sleep(poll_seconds)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/print_supabase_env.py
+++ b/scripts/print_supabase_env.py
@@ -1,0 +1,17 @@
+# scripts/print_supabase_env.py
+
+import os
+import sys
+from dotenv import load_dotenv
+
+# Ensure project root is on sys.path
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+# Load .env from project root
+load_dotenv()
+
+print("SUPABASE_URL:", os.getenv("SUPABASE_URL"))
+print("SUPABASE_SERVICE_KEY set?:", bool(os.getenv("SUPABASE_SERVICE_KEY")))
+print("DATABASE_URL:", os.getenv("DATABASE_URL"))

--- a/scripts/test_email_integration.py
+++ b/scripts/test_email_integration.py
@@ -1,0 +1,141 @@
+# scripts/test_email_integration.py
+from __future__ import annotations
+
+"""
+Ad-hoc integration test for outbound email using Gmail SMTP.
+
+What it does:
+- Looks up a registration by id in Supabase
+- Reads the `email` column
+- Sends 5 emails, 1 minute apart, to that address via Gmail
+
+Prereqs:
+- Supabase env vars set (SUPABASE_URL, SUPABASE_SERVICE_ROLE / *_KEY, SUPABASE_SCHEMA)
+- A row in `registrations` with your Gmail in the `email` column
+- Gmail app password (NOT your normal password)
+
+Usage (from repo root, venv active):
+
+    export TEST_REGISTRATION_ID=<your_registration_id>
+    export GMAIL_SMTP_USER="<your_gmail_address>"
+    export GMAIL_SMTP_PASS="<your_app_password>"
+
+    python scripts/test_email_integration.py
+
+On Windows PowerShell:
+
+    $env:TEST_REGISTRATION_ID="<id>"
+    $env:GMAIL_SMTP_USER="<you@gmail.com>"
+    $env:GMAIL_SMTP_PASS="<app-password>"
+
+    python scripts/test_email_integration.py
+"""
+
+import asyncio
+import os
+import smtplib
+from email.message import EmailMessage
+from typing import Optional
+
+import httpx
+
+from app.data.supabase_repo import _cfg, _headers  # reuse existing helpers
+
+
+# -------------------------------------------------------------
+# Supabase helpers (read email address from registrations)
+# -------------------------------------------------------------
+async def get_registration_email(registration_id: str) -> Optional[str]:
+    """Fetch the `email` field from registrations for the given id."""
+    url, key, schema = _cfg()
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(
+            f"{url}/rest/v1/registrations"
+            f"?id=eq.{registration_id}&select=email",
+            headers={**_headers(key), "Accept-Profile": schema},
+        )
+
+    resp.raise_for_status()
+    rows = resp.json()
+    if not rows:
+        return None
+
+    email = rows[0].get("email")
+    return email
+
+
+# -------------------------------------------------------------
+# Gmail SMTP sender
+# -------------------------------------------------------------
+def send_email_smtp(to_email: str, subject: str, body: str) -> None:
+    """
+    Send a single email via Gmail SMTP.
+
+    Requires:
+      - GMAIL_SMTP_USER
+      - GMAIL_SMTP_PASS  (Gmail app password)
+    """
+    user = os.environ["GMAIL_SMTP_USER"]
+    password = os.environ["GMAIL_SMTP_PASS"]
+
+    host = os.getenv("GMAIL_SMTP_HOST", "smtp.gmail.com")
+    port = int(os.getenv("GMAIL_SMTP_PORT", "587"))
+
+    msg = EmailMessage()
+    msg["From"] = user
+    msg["To"] = to_email
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    with smtplib.SMTP(host, port) as server:
+        server.starttls()
+        server.login(user, password)
+        server.send_message(msg)
+
+
+# -------------------------------------------------------------
+# Main integration flow
+# -------------------------------------------------------------
+async def main() -> None:
+    registration_id = os.environ.get("TEST_REGISTRATION_ID")
+    if not registration_id:
+        raise SystemExit(
+            "TEST_REGISTRATION_ID env var is required. "
+            "Set it to the registrations.id that contains your Gmail."
+        )
+
+    print(f"[email-integration] Looking up registration {registration_id}...")
+    email = await get_registration_email(registration_id)
+
+    if not email:
+        raise SystemExit(
+            f"No email found for registrations.id={registration_id}. "
+            "Check that the row exists and has an `email` column populated."
+        )
+
+    print(f"[email-integration] Will send test emails to: {email}")
+
+    # Send 5 emails, 1 minute apart
+    for i in range(1, 6):
+        subject = f"Cory Test Email #{i}"
+        body = (
+            f"Hi from Cory test #{i}.\n\n"
+            f"This is an automated integration test email.\n"
+            f"Registration id: {registration_id}\n"
+        )
+
+        print(f"[email-integration] Sending email {i}/5...")
+        # run blocking SMTP in a thread to keep asyncio happy
+        await asyncio.to_thread(send_email_smtp, email, subject, body)
+        print(f"[email-integration] Email {i} sent.")
+
+        if i < 5:
+            print("[email-integration] Sleeping 60s before next email...")
+            await asyncio.sleep(60)
+
+    print("[email-integration] Done. Check your Gmail inbox.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_email_integration_flow.py
+++ b/scripts/test_email_integration_flow.py
@@ -1,0 +1,141 @@
+# scripts/test_email_integration_flow.py
+from __future__ import annotations
+
+import os
+import smtplib
+import ssl
+import time
+from email.message import EmailMessage
+
+from dotenv import load_dotenv
+
+
+def _get_smtp_client(host: str, port: int, username: str, password: str, use_tls: bool):
+    """Return a connected SMTP client (STARTTLS or SSL)."""
+    context = ssl.create_default_context()
+    if use_tls:
+        server = smtplib.SMTP(host, port)
+        server.ehlo()
+        server.starttls(context=context)
+        server.login(username, password)
+        return server
+    else:
+        # SSL mode (e.g. port 465)
+        server = smtplib.SMTP_SSL(host, port, context=context)
+        server.login(username, password)
+        return server
+
+
+def _send_email(
+    server: smtplib.SMTP,
+    from_email: str,
+    to_email: str,
+    subject: str,
+    body: str,
+) -> None:
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_email
+    msg["To"] = to_email
+    msg.set_content(body)
+    server.send_message(msg)
+
+
+def main() -> None:
+    load_dotenv()
+
+    host = os.getenv("GMAIL_SMTP_HOST", "smtp.gmail.com")
+    port = int(os.getenv("GMAIL_SMTP_PORT", "587"))
+    username = os.getenv("GMAIL_USERNAME")
+    password = os.getenv("GMAIL_APP_PASSWORD")
+    from_email = os.getenv("SMTP_FROM") or username
+    to_email = os.getenv("GMAIL_TEST_TO") or username  # send to yourself by default
+    use_tls = os.getenv("SMTP_USE_TLS", "true").lower() == "true"
+
+    if not username or not password:
+        raise SystemExit(
+            "❌ Missing GMAIL_USERNAME or GMAIL_APP_PASSWORD in .env. "
+            "Please set them before running this script."
+        )
+
+    # "Stored data" about the student that Cory will use when replying.
+    student_name = os.getenv("TEST_STUDENT_NAME", "Nikhil")
+    program = os.getenv("TEST_PROGRAM", "Computer Science")
+    start_term = os.getenv("TEST_START_TERM", "Fall 2025")
+
+    print("\n=== Cory Email Integration Flow ===")
+    print(f"SMTP Host: {host}")
+    print(f"SMTP Port: {port}")
+    print(f"From:      {from_email}")
+    print(f"To:        {to_email}")
+    print(f"TLS:       {use_tls}")
+    print("-----------------------------------")
+    print("This script will send up to 5 emails, 1 minute apart.")
+    print("After each email, you can mark that the student replied.")
+    print("If you say 'y', Cory sends a personalized reply and stops.\n")
+
+    # Prepare the 5-touch sequence (slightly different messages each time)
+    touches = [
+        f"Hi {student_name}, just checking in about your interest in {program}.",
+        f"Hi {student_name}, we’d love to help you get started for {start_term}.",
+        f"{student_name}, do you have any questions about {program} or next steps?",
+        f"Quick reminder, {student_name}: we’re here to help you enroll for {start_term}.",
+        f"Last nudge, {student_name} — would you like help finishing your application?",
+    ]
+
+    server = _get_smtp_client(host, port, username, password, use_tls)
+
+    try:
+        for idx, body in enumerate(touches, start=1):
+            subject = f"[Cory Test] Touch {idx}/5 about your {program} interest"
+
+            print(f"📤 Sending touch {idx}/5 to {to_email} ...")
+            _send_email(
+                server,
+                from_email=from_email,
+                to_email=to_email,
+                subject=subject,
+                body=(
+                    body
+                    + "\n\n"
+                    "If you reply to this email, imagine a student saying 'Yes, I’m interested.'"
+                ),
+            )
+            print("✅ Email sent. Check your Gmail inbox.")
+
+            # Ask operator if the student has replied yet
+            answer = input("Has the student replied yet? [y/N]: ").strip().lower()
+            if answer == "y":
+                print("🟢 Student replied — sending Cory’s personalized follow-up...")
+                reply_subject = f"[Cory Test] Thanks for your interest in {program}!"
+                reply_body = (
+                    f"Hi {student_name},\n\n"
+                    f"Awesome — thanks for confirming your interest in {program}.\n"
+                    f"For {start_term}, we can set up a quick call to walk through "
+                    f"requirements and deadlines.\n\n"
+                    "Reply with a few times that work for you, or we can schedule a call "
+                    "automatically in the real system.\n\n"
+                    "— Cory Admissions\n"
+                )
+                _send_email(
+                    server,
+                    from_email=from_email,
+                    to_email=to_email,
+                    subject=reply_subject,
+                    body=reply_body,
+                )
+                print("✅ Cory reply sent. Flow complete.")
+                return
+
+            if idx < len(touches):
+                print("⏳ No reply yet. Waiting 60 seconds before the next email...\n")
+                time.sleep(60)
+
+        print("\n🚩 Reached 5 touches with no student reply. Flow finished without response.")
+
+    finally:
+        server.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_gmail_smtp.py
+++ b/scripts/test_gmail_smtp.py
@@ -1,0 +1,71 @@
+# scripts/test_gmail_smtp.py
+from __future__ import annotations
+
+import os
+import smtplib
+import ssl
+from email.message import EmailMessage
+from dotenv import load_dotenv
+
+
+def main() -> None:
+    # Load environment variables
+    load_dotenv()
+
+    host = os.getenv("GMAIL_SMTP_HOST", "smtp.gmail.com")
+    port = int(os.getenv("GMAIL_SMTP_PORT", "587"))
+
+    username = os.getenv("GMAIL_USERNAME")
+    password = os.getenv("GMAIL_APP_PASSWORD")
+    from_email = os.getenv("SMTP_FROM") or username
+    to_email = os.getenv("GMAIL_TEST_TO") or username  # send to yourself
+
+    use_tls = os.getenv("SMTP_USE_TLS", "true").lower() == "true"
+
+    # Validate required fields
+    if not username or not password:
+        raise SystemExit(
+            "❌ Missing GMAIL_USERNAME or GMAIL_APP_PASSWORD in .env.\n"
+            "Please update .env with your Gmail app password."
+        )
+
+    print("\n=== Gmail SMTP Test ===")
+    print(f"SMTP Host: {host}")
+    print(f"SMTP Port: {port}")
+    print(f"From: {from_email}")
+    print(f"To: {to_email}")
+    print(f"TLS: {use_tls}")
+    print("========================\n")
+
+    # Build email
+    msg = EmailMessage()
+    msg["Subject"] = "Cory_dev Gmail SMTP Test ✅"
+    msg["From"] = from_email
+    msg["To"] = to_email
+    msg.set_content(
+        "Hello!\n\n"
+        "This is a test email from your Cory dev environment using Gmail SMTP.\n"
+        "If you're reading this, SMTP login + sending works correctly.\n\n"
+        "— Cory Dev\n"
+    )
+
+    print("📤 Sending email...")
+
+    if use_tls:
+        # TLS mode (STARTTLS on port 587)
+        with smtplib.SMTP(host, port) as server:
+            server.ehlo()
+            server.starttls(context=ssl.create_default_context())
+            server.login(username, password)
+            server.send_message(msg)
+    else:
+        # SSL mode (port 465)
+        with smtplib.SMTP_SSL(host, port, context=ssl.create_default_context()) as server:
+            server.login(username, password)
+            server.send_message(msg)
+
+    print("✅ Email sent! Check your inbox (and spam/promotions).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/manual/test_email_sequence.py
+++ b/tests/manual/test_email_sequence.py
@@ -1,0 +1,169 @@
+# tests/manual/test_email_sequence.py
+"""
+Manual end-to-end email test with reply stop.
+
+Behavior:
+- Sends up to 5 emails, spaced 60s apart.
+- Each email has a unique token in the subject.
+- After each send, poll Gmail via IMAP for up to 60s.
+- If a reply to that thread is detected, stop sending further emails.
+
+Uses:
+- SMTP_* / GMAIL_* env vars from .env
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import smtplib
+import ssl
+import imaplib
+import email
+from email.message import EmailMessage
+from datetime import datetime, timezone
+from typing import Optional
+
+SMTP_HOST = os.getenv("GMAIL_SMTP_HOST", "smtp.gmail.com")
+SMTP_PORT = int(os.getenv("GMAIL_SMTP_PORT", "587"))
+
+USERNAME = os.getenv("GMAIL_USERNAME")
+APP_PASSWORD = os.getenv("GMAIL_APP_PASSWORD")
+
+FROM_EMAIL = os.getenv("SMTP_FROM") or USERNAME
+TO_EMAIL = os.getenv("GMAIL_TEST_TO") or USERNAME  # send to yourself by default
+
+IMAP_HOST = os.getenv("GMAIL_IMAP_HOST", "imap.gmail.com")
+IMAP_PORT = 993  # SSL
+
+if not USERNAME or not APP_PASSWORD:
+    raise RuntimeError("GMAIL_USERNAME and GMAIL_APP_PASSWORD must be set in .env")
+
+
+# ---------------------------------------------------------------------------
+# SMTP helper
+# ---------------------------------------------------------------------------
+
+async def send_smtp_email(to_email: str, subject: str, body: str) -> None:
+    msg = EmailMessage()
+    msg["From"] = FROM_EMAIL
+    msg["To"] = to_email
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    def _send():
+        context = ssl.create_default_context()
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as server:
+            server.starttls(context=context)
+            server.login(USERNAME, APP_PASSWORD)
+            server.send_message(msg)
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, _send)
+
+
+# ---------------------------------------------------------------------------
+# IMAP helpers – check for reply
+# ---------------------------------------------------------------------------
+
+def _search_replies_sync(subject_token: str) -> bool:
+    """
+    Blocking IMAP search: look for any message whose Subject contains
+    'Re:' and the given token. This is crude but good enough for testing.
+    """
+    mail = imaplib.IMAP4_SSL(IMAP_HOST, IMAP_PORT)
+    try:
+        mail.login(USERNAME, APP_PASSWORD)
+        mail.select("INBOX")
+
+        # Search for all recent messages that mention our token in Subject
+        typ, data = mail.search(None, 'SUBJECT', f'"{subject_token}"')
+        if typ != "OK":
+            return False
+
+        ids = data[0].split()
+        if not ids:
+            return False
+
+        # Check if any of these are replies (Subject starts with "Re:")
+        for msg_id in ids:
+            typ, msg_data = mail.fetch(msg_id, "(RFC822)")
+            if typ != "OK" or not msg_data:
+                continue
+            raw = msg_data[0][1]
+            msg = email.message_from_bytes(raw)
+            subj = msg.get("Subject", "")
+            if subj.lower().startswith("re:") and subject_token in subj:
+                return True
+        return False
+    finally:
+        try:
+            mail.logout()
+        except Exception:
+            pass
+
+
+async def wait_for_reply(subject_token: str, timeout: int = 60, poll_interval: int = 10) -> bool:
+    """
+    Poll IMAP every poll_interval seconds (up to timeout) looking for a reply.
+
+    Returns True if a reply is detected, else False.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = datetime.now(timezone.utc).timestamp() + timeout
+
+    while datetime.now(timezone.utc).timestamp() < deadline:
+        has_reply = await loop.run_in_executor(None, _search_replies_sync, subject_token)
+        if has_reply:
+            return True
+        await asyncio.sleep(poll_interval)
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Main test sequence
+# ---------------------------------------------------------------------------
+
+async def send_sequence():
+    print(f"[INFO] Using recipient: {TO_EMAIL}")
+    # Unique token for this run so we don't confuse old threads
+    token = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+    max_emails = 5
+    delay_seconds = 60.0
+
+    for i in range(1, max_emails + 1):
+        subject_token = f"[Cory Test {token}]"
+        subject = f"{subject_token} Nurture Email {i} of {max_emails}"
+        body = (
+            f"This is Cory test nurture email {i} of {max_emails}.\n\n"
+            f"Run token: {token}\n"
+            f"Reply to this email (just hit Reply) and I should stop sending "
+            f"further emails in this sequence."
+        )
+
+        now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        print(f"[SEND] {now} – Sending email {i}/{max_emails}: {subject}")
+
+        await send_smtp_email(TO_EMAIL, subject, body)
+        print(f"[RESULT] {i}/{max_emails}: sent")
+
+        # After each send except the last, wait for a reply
+        if i < max_emails:
+            print(f"[WAIT] Checking for reply for up to 60s (polling IMAP)...")
+            replied = await wait_for_reply(subject_token)
+            if replied:
+                print(f"[STOP] Reply detected on thread token {subject_token}. Stopping sequence.")
+                break
+            else:
+                print(f"[NO REPLY] No reply detected yet. Sleeping {delay_seconds} seconds before next email...")
+                await asyncio.sleep(delay_seconds)
+        else:
+            print("[DONE] Sent final email; sequence complete.")
+
+    print("[DONE] Script finished.")
+
+
+if __name__ == "__main__":
+    asyncio.run(send_sequence())

--- a/tests/unit/test_reengagement_campaign_agent.py
+++ b/tests/unit/test_reengagement_campaign_agent.py
@@ -1,0 +1,99 @@
+# tests/unit/test_reengagement_campaign_agent.py
+from __future__ import annotations
+
+from typing import Dict, Any, List
+
+import pytest
+
+from app.agents.reengagement_campaign_agent import ReengagementCampaignAgent
+
+
+class DummyRepo:
+    """
+    Lightweight in-memory repo so we don't hit real Supabase in unit tests.
+    """
+
+    def __init__(self) -> None:
+        self.steps: List[Dict[str, Any]] = []
+        self.scheduled: List[Dict[str, Any]] = []
+
+    # Ticket 8 helpers used by the agent
+    async def get_reengagement_steps(self, campaign_id: str) -> List[Dict[str, Any]]:
+        # In tests we just return whatever the test stuffed into .steps
+        return self.steps
+
+    async def schedule_reengagement_message(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        # Record what was scheduled so tests can assert on it
+        self.scheduled.append(payload)
+        return payload
+
+
+@pytest.mark.asyncio
+async def test_run_campaign_no_steps(monkeypatch):
+    """
+    If the repo returns no reengagement steps, the agent should
+    return status='no_steps' and not schedule anything.
+    """
+    dummy_repo = DummyRepo()
+
+    # Patch SupabaseRepo inside the agent module to return our dummy instance
+    monkeypatch.setattr(
+        "app.agents.reengagement_campaign_agent.SupabaseRepo",
+        lambda: dummy_repo,
+    )
+
+    agent = ReengagementCampaignAgent()
+
+    result = await agent.run_campaign(
+        lead_id="lead-1",
+        campaign_id="camp-1",
+    )
+
+    assert result["status"] == "no_steps"
+    assert dummy_repo.scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_run_campaign_schedules_all_steps(monkeypatch):
+    """
+    When the repo returns multiple reengagement steps, the agent
+    should schedule all of them via schedule_reengagement_message.
+    """
+    dummy_repo = DummyRepo()
+    dummy_repo.steps = [
+        {"id": "step-1", "template_id": "tmpl-1", "delay_minutes": 0},
+        {"id": "step-2", "template_id": "tmpl-2", "delay_minutes": 60},
+        {"id": "step-3", "template_id": "tmpl-3"},  # relies on default delay
+    ]
+
+    monkeypatch.setattr(
+        "app.agents.reengagement_campaign_agent.SupabaseRepo",
+        lambda: dummy_repo,
+    )
+
+    agent = ReengagementCampaignAgent()
+    ctx = {"reason": "no_response_30_days"}
+
+    result = await agent.run_campaign(
+        lead_id="lead-123",
+        campaign_id="camp-xyz",
+        context=ctx,
+    )
+
+    # High-level result
+    assert result["status"] == "ok"
+    assert result["steps_scheduled"] == len(dummy_repo.steps)
+    assert len(dummy_repo.scheduled) == len(dummy_repo.steps)
+
+    # Each scheduled payload should have the right shape
+    for original_step, scheduled in zip(dummy_repo.steps, dummy_repo.scheduled):
+        assert scheduled["lead_id"] == "lead-123"
+        assert scheduled["campaign_id"] == "camp-xyz"
+        assert scheduled["step_id"] == original_step["id"]
+        assert scheduled["template_id"] == original_step["template_id"]
+        assert scheduled["context"] == ctx
+
+        # scheduled_for should be an ISO-8601 string
+        assert "scheduled_for" in scheduled
+        assert isinstance(scheduled["scheduled_for"], str)
+        assert "T" in scheduled["scheduled_for"]  # crude but enough for unit test


### PR DESCRIPTION
This PR adds inbound email ingestion and prepares Cory to stop email nurtures when a student replies.

What’s included:
- IMAP-based email ingest daemon (polling every 30s)
- Robust .env loading and logging
- Supabase service-role integration for inbound writes
- Inbound email parsing + lead lookup
- Interaction logging for inbound email
- Temporal groundwork for reply-based nurture stopping
- Manual test scripts for email workflows

How to run:
- python -m scripts.email_ingest_daemon

Env required:
- IMAP_HOST, IMAP_USERNAME, IMAP_PASSWORD
- SUPABASE_URL
- SUPABASE_SERVICE_ROLE_KEY

Notes:
- Inbound emails from unknown senders are safely ignored
- Final step pending: end-to-end test with a real lead reply
